### PR TITLE
Hide credentials in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ error_log
 .env
 .env.local
 .env.*.php
+tests/.env
 insta_session.txt

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -1,0 +1,2 @@
+USERNAME="seu_usuario"
+PASSWORD="sua_senha"

--- a/tests/rocketInstaTest.php
+++ b/tests/rocketInstaTest.php
@@ -2,6 +2,16 @@
 
 require '../vendor/autoload.php';
 
+// Carrega credenciais do arquivo .env localizado nesta pasta
+$envFile = __DIR__ . '/.env';
+$env = [];
+if (file_exists($envFile)) {
+    $env = parse_ini_file($envFile);
+}
+
+$username = $env['USERNAME'] ?? '';
+$password = $env['PASSWORD'] ?? '';
+
 use RocketInsta\rocketInsta;
 
 $insta = new rocketInsta(true);
@@ -9,7 +19,7 @@ $insta = new rocketInsta(true);
 if ($insta->loadSession()) {
     echo "Sessão já ativa!";
 } else {
-    $loginResult = $insta->login('poucafe.oficial', 'ZSefZFUWMaGu5R', true);
+    $loginResult = $insta->login($username, $password, true);
 
     if ($loginResult === true) {
         echo "Login bem-sucedido!";


### PR DESCRIPTION
## Summary
- avoid committing Instagram username and password directly in tests
- load credentials from a `.env` file
- provide a `.env.example` and ignore actual `.env`

## Testing
- `php -l tests/rocketInstaTest.php`
- `php -l src/rocketInsta.php`
- `php tests/rocketInstaTest.php` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876917e3b08832e8df032e60dedd583