### PR TITLE
Rename rocketInsta class

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ composer require rocket/insta-api
 
 require '../vendor/autoload.php';
 
-use RocketInsta\rocketInsta;
+use Rocket\rocketInstaAPI;
 
-$insta = new rocketInsta(true);
+$insta = new rocketInstaAPI(true);
 
 if ($insta->loadSession()) {
     echo "Sessão já ativa!";

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   },
   "autoload": {
     "psr-4": {
-      "RocketInsta\\": "src/"
+      "Rocket\\": "src/"
     }
   }
 }

--- a/src/rocketInstaAPI.php
+++ b/src/rocketInstaAPI.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RocketInsta;
+namespace Rocket;
 
-class rocketInsta
+class rocketInstaAPI
 {
     private $cookieFile;
     private $userAgent;

--- a/tests/rocketInstaTest.php
+++ b/tests/rocketInstaTest.php
@@ -12,9 +12,9 @@ if (file_exists($envFile)) {
 $username = $env['USERNAME'] ?? '';
 $password = $env['PASSWORD'] ?? '';
 
-use RocketInsta\rocketInsta;
+use Rocket\rocketInstaAPI;
 
-$insta = new rocketInsta(true);
+$insta = new rocketInstaAPI(true);
 
 if ($insta->loadSession()) {
     echo "Sessão já ativa!";


### PR DESCRIPTION
## Summary
- rename class to `rocketInstaAPI`
- change namespace from `RocketInsta` to `Rocket`
- update README and tests
- fix Composer autoload mapping

## Testing
- `composer validate --no-check-all`
- `composer dump-autoload`
- `php -l src/rocketInstaAPI.php`
- `php -l tests/rocketInstaTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6877ec620440832ebe95a59eb5cf1da1